### PR TITLE
Adding RedHat support and improving the elasticsearch output

### DIFF
--- a/manifests/common/headers.pp
+++ b/manifests/common/headers.pp
@@ -6,7 +6,7 @@ define beats::common::headers (
   $ignore_outgoing       = $beats::ignore_outgoing,
   $uid                   = $beats::uid,
   $gid                   = $beats::gid,
-  $geoip_paths           = ['/usr/share/GeoIP/GeoIPCity.dat'],
+  $geoip_paths           = hiera('geoip_paths',['/usr/share/GeoIP/GeoIPCity.dat']),
 ) {
   concat { "/etc/${title}/${title}.yml":
     group   => 'root',

--- a/manifests/filebeat.pp
+++ b/manifests/filebeat.pp
@@ -15,11 +15,21 @@ class beats::filebeat (
     notify  => Service['filebeat'],
   }
 
-  include ::apt::update
+  case $::osfamily {
+    'Debian': {
+      include ::apt::update
 
-  package {'filebeat':
-    ensure  => $ensure,
-    require => Class['apt::update']
+      package {'filebeat':
+        ensure  => $ensure,
+        require => Class['apt::update']
+      }
+    }
+    'RedHat': {
+      package {'filebeat':
+        ensure  => $ensure,
+      }
+    }
+    default: { fail("${::osfamily} not supported yet") }
   }
   service { 'filebeat':
     ensure => running,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -52,7 +52,16 @@ class beats (
     $_outputs_elasticsearch = $outputs_elasticsearch
     $_outputs_file = $outputs_file
   }
-
-  include beats::repo::apt, beats::package, beats::config
-  Class['beats::repo::apt'] -> Class['beats::package'] -> Class['beats::config']
+  
+  case $::osfamily {
+    'RedHat': {
+      include beats::repo::yum, beats::package, beats::config
+      Class['beats::repo::yum'] -> Class['beats::package'] -> Class['beats::config']
+    }
+    'Debian': {
+      include beats::repo::apt, beats::package, beats::config
+      Class['beats::repo::apt'] -> Class['beats::package'] -> Class['beats::config']
+    }
+    default: { fail("${::osfamily} not supported yet") }
+  }
 }

--- a/manifests/outputs/elasticsearch.pp
+++ b/manifests/outputs/elasticsearch.pp
@@ -3,7 +3,10 @@
 define beats::outputs::elasticsearch (
   $hosts = ['localhost:9200'],
   $save_topology = true,
-  $index = 'packetbeat',
+  $index = $title,
+  $username = '',
+  $password = '',
+  $http_path = '',
   $outputs = $beats::outputs
 ) {
   concat::fragment {"${title}-output-elasticsearch":

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -9,6 +9,11 @@ class beats::package (
         ensure => installed,
       }
     }
+    'RedHat': {
+      package { 'libpcap':
+        ensure => installed,
+      }
+    }
     default: { fail("${::osfamily} not supported yet") }
   }
   if $beats::manage_geoip {
@@ -20,6 +25,11 @@ class beats::package (
       }
       'Debian': {
         package { 'geoip-database-extra':
+          ensure => latest,
+        }
+      }
+      'CentOS': {
+        package { 'GeoIP':
           ensure => latest,
         }
       }

--- a/manifests/packetbeat.pp
+++ b/manifests/packetbeat.pp
@@ -24,12 +24,24 @@ class beats::packetbeat (
   $pgsql_max_rows            = undef,
   $pgsql_max_row_length      = undef,
 ){
-  include ::apt::update
   include beats::packetbeat::config
-  package {'packetbeat':
-    ensure  => $beats::packetbeat::ensure,
-    require => Class['apt::update']
+  
+  case $::osfamily {
+    'Debian': {
+      include ::apt::update
+      package {'packetbeat':
+        ensure  => $beats::packetbeat::ensure,
+        require => Class['apt::update']
+      }
+    }
+    'RedHat': {
+      package {'packetbeat':
+        ensure  => $beats::packetbeat::ensure,
+      }
+    }
+    default: { fail("${::osfamily} not supported yet") }
   }
+  
   service { 'packetbeat':
     ensure => running,
     enable => true,

--- a/manifests/repo/yum.pp
+++ b/manifests/repo/yum.pp
@@ -1,16 +1,15 @@
-# Placeholder for when there are official repos
 class beats::repo::yum {
 
   ## This is a freely available repo by packagecloud.  Not maintained
   ## As soon as ES provides upstream packages this repo should be obsoleted
-  yumrepo { 'krisbuytaert_monitoringstuff':
+  yumrepo { 'beats':
     ensure   => 'present',
-    baseurl  => 'https://packagecloud.io/krisbuytaert/monitoringstuff/el/6/$basearch',
-    descr    => 'krisbuytaert_monitoringstuff',
+    baseurl  => 'https://packages.elastic.co/beats/yum/el/$basearch',
+    descr    => 'ES beats repository',
     enabled  => '1',
-    gpgcheck => '0',
+    gpgcheck => '1',
+    gpgkey   => 'http://packages.elastic.co/GPG-KEY-elasticsearch'
   }
-
 
 }
 

--- a/manifests/topbeat.pp
+++ b/manifests/topbeat.pp
@@ -7,13 +7,25 @@ class beats::topbeat (
   $stats_proc       = true,
   $stats_filesystem = true,
 ){
-  include ::apt::update
-  include beats::topbeat::config
-
-  package {'topbeat':
-    ensure  => $ensure,
-    require => Class['apt::update']
+  
+  case $::osfamily {
+    'Debian': {
+      include ::apt::update
+      package {'topbeat':
+        ensure  => $ensure,
+        require => Class['apt::update']
+      }
+    }
+    'RedHat': {
+      package {'topbeat':
+        ensure  => $ensure,
+      }
+    }
+    default: { fail("${::osfamily} not supported yet") }
   }
+
+  include beats::topbeat::config
+  
   service { 'topbeat':
     ensure => running,
     enable => true,

--- a/templates/outputs/elasticsearch.erb
+++ b/templates/outputs/elasticsearch.erb
@@ -1,24 +1,86 @@
   elasticsearch:
-    enabled: true
-    host: <%= @es_host %>
-    port: <%= @es_port %>
-    es_save_topology: <%= @es_save_topology %>
-<% if @es_protocol %>
-    # Protocol and auth credentials
-    es_protocol: <%= @es_protocol %>
+    # Array of hosts to connect to.
+    # Scheme and port can be left out and will be set to the default (http and 9200)
+    # In case you specify and additional path, the scheme is required: http://localhost:9200/path
+    # IPv6 addresses should always be defined as: https://[2001:db8::1]:9200
+    hosts: <%= @hosts %>
+<% if @protocol && !@protocol.empty? %>
+    # Optional protocol and basic auth credentials.
+    protocol: <%= @protocol %>
 <% end -%>
-<% if @es_username %>
-    es_username: <%= @es_username %>
+<% if @username && !@username.empty? %>
+    username: <%= @username %>
 <% end -%>
-<% if @es_password %>
-    es_password: <%= @es_password %>
+<% if @password && !@password.empty? %>
+    password: <%= @password %>
 <% end -%>
-<% if @es_index %>
+    # Number of workers per Elasticsearch host.
+    # worker: 1
+<% if @index && !@index.empty? %>
+    # Optional index name. The default is "topbeat" and generates
+    # [topbeat-]YYYY.MM.DD keys.
     # Custom index location
-    es_index: <%= @es_index %>
+    index: <%= @index %>
 <% end %>
-<% if @es_http_path %>  
-    # Custom HTTP path to ES
-    path: <%= @es_http_path %>
+<% if @http_path && !@http_path.empty? %>  
+    # Optional HTTP Path
+    path: <%= @http_path %>
 <% end %>
+   # Proxy server url
+    #proxy_url: http://proxy:3128
+
+    # The number of times a particular Elasticsearch index operation is attempted. If
+    # the indexing operation doesn't succeed after this many retries, the events are
+    # dropped. The default is 3.
+    #max_retries: 3
+
+    # The maximum number of events to bulk in a single Elasticsearch bulk API index request.
+    # The default is 50.
+    #bulk_max_size: 50
+
+    # Configure http request timeout before failing an request to Elasticsearch.
+    #timeout: 90
+
+    # The number of seconds to wait for new events between two bulk API index requests.
+    # If `bulk_max_size` is reached before this interval expires, addition bulk index
+    # requests are made.
+    #flush_interval: 1
+
+    # Boolean that sets if the topology is kept in Elasticsearch. The default is
+    # false. This option makes sense only for Packetbeat.
+    save_topology: <%= @save_topology %>
+
+    # The time to live in seconds for the topology information that is stored in
+    # Elasticsearch. The default is 15 seconds.
+    #topology_expire: 15
+
+    # tls configuration. By default is off.
+    #tls:
+      # List of root certificates for HTTPS server verifications
+      #certificate_authorities: ["/etc/pki/root/ca.pem"]
+
+      # Certificate for TLS client authentication
+      #certificate: "/etc/pki/client/cert.pem"
+
+      # Client Certificate Key
+      #certificate_key: "/etc/pki/client/cert.key"
+
+      # Controls whether the client verifies server certificates and host name.
+      # If insecure is set to true, all server host names and certificates will be
+      # accepted. In this mode TLS based connections are susceptible to
+      # man-in-the-middle attacks. Use only for testing.
+      #insecure: true
+
+      # Configure cipher suites to be used for TLS connections
+      #cipher_suites: []
+
+      # Configure curve types for ECDHE based cipher suites
+      #curve_types: []
+
+      # Configure minimum TLS version allowed for connection to logstash
+      #min_version: 1.0
+
+      # Configure maximum TLS version allowed for connection to logstash
+      #max_version: 1.2
+
 


### PR DESCRIPTION
This merge request introduces support for RedHat. I also found some issues with the format of the configuration file for the output to Elasticsearch which are fixed here as well. The template now contains the comments and explanations of the different parameters as can be found in the template which comes with the package. 
The patches have been tested with CentOS7 and work fine for us. 
Feedback is welcome. 
