### PR TITLE
Added config to filebeat and fixed dependency cycle problem

### DIFF
--- a/manifests/filebeat.pp
+++ b/manifests/filebeat.pp
@@ -6,15 +6,7 @@ class beats::filebeat (
   $registry_file = '/var/lib/filebeat/registry',
   $spool_size    = 1024,
 ){
-
-  beats::common::headers {'filebeat':}
-  concat::fragment {'filebeat.header':
-    target  => '/etc/filebeat/filebeat.yml',
-    content => template('beats/filebeat/filebeat.yml.erb'),
-    order   => 05,
-    notify  => Service['filebeat'],
-  }
-
+  include beats::filebeat::config
   case $::osfamily {
     'Debian': {
       include ::apt::update
@@ -35,10 +27,6 @@ class beats::filebeat (
     ensure => running,
     enable => true,
   }
-  if $prospectors {
-    create_resources('::beats::filebeat::prospector', $prospectors )
-  }
-
-  Package['filebeat'] -> Concat::Fragment['filebeat.header'] ->
-  Beats::Filebeat::Prospector <||> ~> Service['filebeat']
+  Package['filebeat'] -> Class['beats::filebeat::config'] ~>
+  Service['filebeat']
 }

--- a/manifests/filebeat/config.pp
+++ b/manifests/filebeat/config.pp
@@ -1,0 +1,12 @@
+# Filebeat config
+class beats::filebeat::config inherits beats::filebeat {
+  beats::common::headers {'filebeat':}
+  concat::fragment {'filebeat.header':
+    target  => '/etc/filebeat/filebeat.yml',
+    content => template('beats/filebeat/filebeat.yml.erb'),
+    order   => 05,
+  }
+if $::prospectors {
+  create_resources('::beats::filebeat::prospector', $::prospectors )
+  }
+}

--- a/manifests/filebeat/prospector.pp
+++ b/manifests/filebeat/prospector.pp
@@ -1,6 +1,6 @@
 # Define::filebeat::prospector
 # Creates prospectors for filebeat
-define beats::filebeat::prospector(
+define beats::filebeat::prospector (
   $paths                 = [],
   $fields                = {},
   $encoding              = undef,
@@ -13,10 +13,11 @@ define beats::filebeat::prospector(
   $backoff_factor        = undef,
   $partial_line_waiting  = undef,
   $force_close_files     = false,
-){
-  concat::fragment {"prospector-${title}":
-    target  => '/etc/filebeat/filebeat.yml',
-    content => template('beats/filebeat/prospector.yml.erb'),
-    order   => 17,
+)
+{
+concat::fragment {"prospector-${title}":
+  target  => '/etc/filebeat/filebeat.yml',
+  content => template('beats/filebeat/prospector.yml.erb'),
+  order   => 17,
   }
 }

--- a/manifests/packetbeat.pp
+++ b/manifests/packetbeat.pp
@@ -25,7 +25,7 @@ class beats::packetbeat (
   $pgsql_max_row_length      = undef,
 ){
   include beats::packetbeat::config
-  
+
   case $::osfamily {
     'Debian': {
       include ::apt::update
@@ -41,7 +41,7 @@ class beats::packetbeat (
     }
     default: { fail("${::osfamily} not supported yet") }
   }
-  
+
   service { 'packetbeat':
     ensure => running,
     enable => true,


### PR DESCRIPTION
HI,

In the filebeat module, the services was starting before the config was updated correctly, so if you deploy this on a node running elasticsearch, filebeat will use the default config and write data to localhost:9200. 

I have created a config file for filebeat and re-chained the dependency, no it looks like the packetbeat module. 
