### PR TITLE
Add basic TLS support for logstash output

### DIFF
--- a/manifests/outputs/logstash.pp
+++ b/manifests/outputs/logstash.pp
@@ -5,6 +5,7 @@ define beats::outputs::logstash (
   $index = $title,
   $worker = 2,
   $loadbalance = false,
+  $tls = false,
 ) {
   concat::fragment {"${title}-output-logstash":
     target  => "/etc/${title}/${title}.yml",

--- a/templates/outputs/logstash.erb
+++ b/templates/outputs/logstash.erb
@@ -3,3 +3,8 @@
     index: <%= @index %>
     worker: <%= @worker %>
     loadbalance: <%= @loadbalance %>
+<%- if @tls -%>    tls:<% @tls.each do |key, value| %>
+      <%= key -%>: <%= value -%><%- end -%>
+<%- end -%>
+
+


### PR DESCRIPTION
This is a very basic addition to the logstash output template which will allow populating TLS related
parameters if they are found to be defined in Hiera (e.g: enabling TLS and defining path to the host certificates and keys):

```yaml
beats::outputs_logstash:
  filebeat:
    hosts: ['blahblah.cern.ch:5044']
    index: 'myindex'
    tls:
      certificate: "/path/to/certificates/hostcert.pem"
      certificate_key: "/path/to/certificates/hostkey.pem"
```