### PR TITLE
add support for metricbeat

### DIFF
--- a/manifests/metricbeat.pp
+++ b/manifests/metricbeat.pp
@@ -1,0 +1,35 @@
+# Metricbeat class
+class beats::metricbeat (
+  $ensure           = present,
+  $period           = 10,
+  $procs            = ['.*'],
+  $stats_system     = true,
+  $stats_proc       = true,
+  $stats_filesystem = true,
+){
+
+  case $::osfamily {
+    'Debian': {
+      include ::apt::update
+      package {'metricbeat':
+        ensure  => $ensure,
+        require => Class['apt::update']
+      }
+    }
+    'RedHat': {
+      package {'metricbeat':
+        ensure  => $ensure,
+      }
+    }
+    default: { fail("${::osfamily} not supported yet") }
+  }
+
+  include beats::metricbeat::config
+
+  service { 'metricbeat':
+    ensure => running,
+    enable => true,
+  }
+
+  Package['metricbeat'] -> Class['beats::metricbeat::config'] ~> Service['metricbeat']
+}

--- a/manifests/metricbeat/config.pp
+++ b/manifests/metricbeat/config.pp
@@ -1,0 +1,9 @@
+# Configure metricbeat class
+class beats::metricbeat::config inherits beats::metricbeat {
+  beats::common::headers {'metricbeat':}
+  concat::fragment {'metricbeat.header':
+    target  => '/etc/metricbeat/metricbeat.yml',
+    content => template('beats/metricbeat/metricbeat.yml.erb'),
+    order   => 06,
+  }
+}

--- a/manifests/outputs/elasticsearch.pp
+++ b/manifests/outputs/elasticsearch.pp
@@ -7,7 +7,8 @@ define beats::outputs::elasticsearch (
   $username = '',
   $password = '',
   $http_path = '',
-  $outputs = $beats::outputs
+  $outputs = $beats::outputs,
+  $period = '10'
 ) {
   concat::fragment {"${title}-output-elasticsearch":
     target  => "/etc/${title}/${title}.yml",

--- a/templates/metricbeat/metricbeat.yml.erb
+++ b/templates/metricbeat/metricbeat.yml.erb
@@ -1,0 +1,50 @@
+###################### Metricbeat Configuration Example #######################
+
+# This file is an example configuration file highlighting only the most common
+# options. The metricbeat.full.yml file from the same directory contains all the
+# supported options with more comments. You can use it as a reference.
+#
+# You can find the full configuration reference here:
+# https://www.elastic.co/guide/en/beats/metricbeat/index.html
+
+#==========================  Modules configuration ============================
+metricbeat.modules:
+
+#------------------------------- System Module -------------------------------
+- module: system
+  metricsets:
+  <% if @stats_system -%>
+    # CPU stats
+    - cpu
+
+    # System Load stats
+    - load
+
+    # Per CPU core stats
+    #- core
+  
+    # IO stats
+    #- diskio
+  <%- end -%>
+  <%- if @stats_filesystem %>
+    # Per filesystem stats
+    - filesystem
+
+    # File system summary stats
+    #- fsstat
+  <%-end-%>
+  <%- if @stats_proc %>
+ 
+    # Memory stats
+    - memory
+
+    # Network stats
+    - network
+
+    # Per process stats
+    - process
+  <%-end-%>
+  enabled: true
+  period:  <%= @period %>
+  processes: <%= @procs.to_json %>
+


### PR DESCRIPTION
This patch provides initial support for metricbeat which replaces topbeat for Elasticsearch 5.x.